### PR TITLE
Updating maven-bundle-plugin to latest tested working version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,7 +549,7 @@ under the License.
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>4.1.0</version>
+          <version>5.1.1</version>
         </plugin>
 
         <!-- FileVault Content Package Plugin -->


### PR DESCRIPTION
This resolved maven build issues for me across all kestros repositories.  Seems the parent artifact which had its version specified caused dependent repositories to throw version errors.